### PR TITLE
chore: bump JSS dep to ^0.0.197

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "linked-data"
   ],
   "dependencies": {
-    "javascript-solid-server": "^0.0.154"
+    "javascript-solid-server": "^0.0.197"
   }
 }


### PR DESCRIPTION
Fixes #19.

## What

`package.json`: `javascript-solid-server: ^0.0.154` → `^0.0.197`.

## Why

nosdav-server was 43 patch releases behind JSS. The bump picks up every fix shipped since, most notably:

- **#471** — git auto-init pins HEAD to `main`. Without this, `git push <nosdav>/path HEAD:main` to a fresh nosdav-served path silently creates a ref but leaves the working tree empty (we hit this on jspod and fixed it upstream).
- **#437 / #443** — `--provision-keys` owner-key provisioning. The foundation for the next planned change (flip nosdav into a Nostr-default wrapper by setting `--provision-keys` ON by default).
- **#466 / #469** — first-push auto-init, regular (non-bare) repos.

## Verified

- `npm install` resolves cleanly to 0.0.197
- `nosdav` startup banner: `JavaScript Solid Server v0.0.197`
- `GET /` returns 200 on a fresh data dir

## Follow-ups (separate issues)

- Flip `--provision-keys` ON by default — the Nostr-default positioning move
- Re-evaluate `--public` default after `--provision-keys` is on
- Adopt jspod's arg-parsing fix (current code treats `--port 8080` as flag-only)
- Borrow polish from jspod: port hopping, auto-open, `--help`, `--version`