### PR TITLE
docs: invocation is `npx nosdav-server`, not `npx nosdav`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ NosDAV gives you a personal Solid pod with a Nostr identity baked in. One comman
 ## Try in 60 seconds
 
 ```bash
-npx nosdav
+npx nosdav-server
 ```
 
 A Schnorr secp256k1 owner keypair is generated on first start, stored at `<pod>/private/privkey.jsonld`, and published in your WebID profile as a Multikey verification method. Your pod becomes its own DID resolver via `/.well-known/did/nostr/<pubkey>`. The same pod also speaks normal Solid — WebID, ACL, OIDC, LDP, content negotiation, WebSocket notifications, git push/clone — all of JSS's features unchanged.
@@ -39,7 +39,7 @@ NosDAV is the **Nostr-default** wrapper. [jspod](https://github.com/JavaScriptSo
 | **Auth** | on by default | on by default |
 | **Same underlying server** | JSS | JSS |
 
-If you want Nostr identity on your pod from day one, run `npx nosdav`. If you want a Solid-only personal pod, run `npx jspod`. The data on disk is portable between them.
+If you want Nostr identity on your pod from day one, run `npx nosdav-server`. If you want a Solid-only personal pod, run `npx jspod`. The data on disk is portable between them.
 
 ## What's installed
 

--- a/docs.html
+++ b/docs.html
@@ -101,19 +101,19 @@ nav.toc a{margin-right:1em}
 <h2 id="auth-ladder">Auth ladder</h2>
 <p>nosdav ships you onto rung 1 (default <code>me</code>/<code>me</code>) and makes climbing visible. The dashboard at <code>/account.html</code> exposes a Change password form (rung 2). Passkey support (rung 3) is on the roadmap. See <a href="https://github.com/nosdav/server/issues/6">nosdav#6</a> for the full ladder framing.</p>
 <p>To set a custom initial password without going through the UI:</p>
-<pre>JSS_SINGLE_USER_PASSWORD='your-password' npx nosdav</pre>
+<pre>JSS_SINGLE_USER_PASSWORD='your-password' npx nosdav-server</pre>
 
 <h2 id="backup">Backup &amp; reset</h2>
 <p>Your entire pod — content, identity, signing keys — is one directory.</p>
 
 <h3>Backup</h3>
 <pre>tar -czf my-pod.tar.gz pod-data/</pre>
-<p>Restore by extracting the tarball back into a pod-data directory and pointing <code>npx nosdav --root /path/to/pod-data</code> at it.</p>
+<p>Restore by extracting the tarball back into a pod-data directory and pointing <code>npx nosdav-server --root /path/to/pod-data</code> at it.</p>
 
 <h3>Reset / "delete account"</h3>
 <p>JSS disables the <code>/idp/account/delete</code> endpoint in single-user mode (the account <em>is</em> the pod). To start completely fresh:</p>
 <pre>rm -rf pod-data
-npx nosdav</pre>
+npx nosdav-server</pre>
 <p>A new <code>me</code>/<code>me</code> account is seeded on next start.</p>
 
 <h2 id="apps">Bundled Solid apps</h2>
@@ -133,7 +133,7 @@ git remote add pod http://localhost:5444/public/apps/penny
 git push pod main</pre>
 <p>Note: <code>git push</code> against a Solid pod needs the same DPoP-bound auth as any other Solid write. Easiest workaround today is to set an <code>Authorization</code> header via <code>git -c http.extraHeader=...</code> with a token obtained from <code>/signin.html</code>. Cleaner ergonomics are a known gap.</p>
 
-<p>To opt out: <code>npx nosdav --no-git</code>.</p>
+<p>To opt out: <code>npx nosdav-server --no-git</code>.</p>
 
 <h2 id="links">Links</h2>
 <ul>


### PR DESCRIPTION
Fixes #24. Two-file sed swap. The CLI itself (`nosdav --flag`) is unchanged — only the `npx` invocation gets the full package name. Reclaiming the bare `nosdav` name is a separate follow-up.