### PR TITLE
chore: bump to 0.0.68

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosdav-server",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "description": "NosDAV — Nostr-native Solid storage server, powered by JSS",
   "type": "module",
   "main": "bin/nosdav.js",


### PR DESCRIPTION
Releases #25 + #27 — Nostr relay (`--nostr`) on by default, README/docs use `npx nosdav-server` invocation.