### PR TITLE
chore: bump to 0.0.69 + jss 0.0.198

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosdav-server",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "description": "NosDAV — Nostr-native Solid storage server, powered by JSS",
   "type": "module",
   "main": "bin/nosdav.js",
@@ -46,6 +46,6 @@
   },
   "dependencies": {
     "chalk": "^5.6.2",
-    "javascript-solid-server": "^0.0.197"
+    "javascript-solid-server": "^0.0.198"
   }
 }


### PR DESCRIPTION
Picks up JSS 0.0.198, which adds the `jss install` subcommand (Phase 1+2+4 of JSS#464).

## Changes
- `javascript-solid-server`: `^0.0.197` → `^0.0.198`
- `version`: `0.0.68` → `0.0.69`

## nosdav's own `install` subcommand

Unchanged. Follow-up will delegate once JSS install stabilizes.