### PR TITLE
chore: bump to 0.0.70 + jss 0.0.199

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosdav-server",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "description": "NosDAV — Nostr-native Solid storage server, powered by JSS",
   "type": "module",
   "main": "bin/nosdav.js",
@@ -46,6 +46,6 @@
   },
   "dependencies": {
     "chalk": "^5.6.2",
-    "javascript-solid-server": "^0.0.198"
+    "javascript-solid-server": "^0.0.199"
   }
 }


### PR DESCRIPTION
Picks up JSS 0.0.199, which adds:

- `jss install --bundle <source>` (apt-style meta-packages)
- bundle resolver uses `/HEAD/` (works for `main`- and `gh-pages`-default repos)
- in-repo `docs/app-install.md`