### PR TITLE
chore: bump to 0.0.71 + jss 0.0.200 (MCP capstone)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosdav-server",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "NosDAV — Nostr-native Solid storage server, powered by JSS",
   "type": "module",
   "main": "bin/nosdav.js",
@@ -46,6 +46,6 @@
   },
   "dependencies": {
     "chalk": "^5.6.2",
-    "javascript-solid-server": "^0.0.199"
+    "javascript-solid-server": "^0.0.200"
   }
 }


### PR DESCRIPTION
Picks up JSS 0.0.200 — the feature-complete capstone. New in JSS:

- \`jss start --mcp\` exposes the pod as a Model Context Protocol server (#491)
- 12 tools across CRUD / Skills / Docs / Introspect, WAC-gated per request
- Skill discovery walks SKILL.md at pod/app/bot scopes

After this, \`npx nosdav-server --mcp\` boots a Nostr-first pod that any MCP-compatible agent (Claude Desktop, Cursor, custom bots) can register as a tool surface. Pairs naturally with NIP-98 auth — Nostr-native agents authenticate to MCP tool calls with Schnorr signatures.