### PR TITLE
feat: --mcp passthrough + 0.0.72

### DIFF
--- a/bin/nosdav.js
+++ b/bin/nosdav.js
@@ -348,6 +348,10 @@ for (let i = 0; i < args.length; i++) {
     options.provisionKeys = true;
   } else if (arg === '--no-provision-keys') {
     options.provisionKeys = false;
+  } else if (arg === '--mcp') {
+    options.mcp = true;
+  } else if (arg === '--no-mcp') {
+    options.mcp = false;
   } else if (arg === '--nostr') {
     options.nostr = true;
   } else if (arg === '--no-nostr') {
@@ -375,6 +379,7 @@ for (let i = 0; i < args.length; i++) {
     console.log(chalk.green('  --no-git') + chalk.dim('               Disable JSS\'s git HTTP backend (it is on by default)'));
     console.log(chalk.green('  --no-provision-keys') + chalk.dim('     Skip auto-generating a Nostr owner keypair (default: on)'));
     console.log(chalk.green('  --no-nostr') + chalk.dim('              Disable the Nostr relay at <pod>/relay (default: on)'));
+    console.log(chalk.green('  --mcp') + chalk.dim('                  Expose /mcp (Model Context Protocol) tool surface for agents'));
     console.log(chalk.green('  -v, --version') + chalk.dim('           Show nosdav version'));
     console.log(chalk.green('  --help') + chalk.dim('                  Show this help message\n'));
     console.log(chalk.white('Examples:'));
@@ -634,6 +639,7 @@ jssArgs.push(options.git ? '--git' : '--no-git');
 // verificationMethod. Pairs with the existing /.well-known/did/nostr/
 // resolution endpoint so the pod becomes its own DID resolver.
 if (options.provisionKeys) jssArgs.push('--provision-keys');
+if (options.mcp) jssArgs.push('--mcp');
 
 // JSS's --nostr enables a Nostr relay at <pod>/relay with NIP-98 auth.
 // On by default for nosdav's Nostr-native positioning.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosdav-server",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "description": "NosDAV — Nostr-native Solid storage server, powered by JSS",
   "type": "module",
   "main": "bin/nosdav.js",


### PR DESCRIPTION
Wires `--mcp` through to `jss start`. After this, `npx nosdav-server --mcp` lights up the MCP server (the v0.0.200 capstone) through the wrapper.

Symmetric to jspod#51 — same wrapper-passthrough bug, same fix shape.