### PR TITLE
chore: bump to 0.0.73 + jss 0.0.201 (MCP follow-ups)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosdav-server",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "NosDAV — Nostr-native Solid storage server, powered by JSS",
   "type": "module",
   "main": "bin/nosdav.js",
@@ -46,6 +46,6 @@
   },
   "dependencies": {
     "chalk": "^5.6.2",
-    "javascript-solid-server": "^0.0.200"
+    "javascript-solid-server": "^0.0.201"
   }
 }


### PR DESCRIPTION
Picks up JSS 0.0.201:

- #497 — subscribe / read_acl / write_acl / call_remote_pod (16 tools total)
- #498 — write_acl lock-yourself-out safety + Footguns docs